### PR TITLE
Make description in route tile prettier and route name not overflow

### DIFF
--- a/lib/Baseitems/Routes.dart
+++ b/lib/Baseitems/Routes.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:intl/intl.dart';
 import 'package:rock_carrot/Baseitems/BaseItems.dart';
 import 'package:rock_carrot/Baseitems/Rocks.dart';
 import 'package:rock_carrot/Database/sql.dart';
@@ -71,7 +72,16 @@ class Route extends BaseItem {
   }
 
   String get firstAscentDate {
-    return _erstbegdatum.substring(0, 4);
+    if (_erstbegdatum != '0000-00-00'){
+      DateTime date = DateFormat('yyyy-MM-dd').parse(_erstbegdatum); //parse date 
+      return DateFormat('d.M.yy').format(date); // use same format as in the climbing guide
+    } 
+    else if (_erstbegnachstieg.contains(r'vor ')) { //year of ascent in _erstbegnachstieg
+      return _erstbegnachstieg.substring(_erstbegnachstieg.indexOf(r'vor ')); 
+    }
+    else {
+      return '';
+    }
   }
 
   String get firstAscentLead {
@@ -79,7 +89,11 @@ class Route extends BaseItem {
   }
 
   String get firstAscentPartners {
-    return _erstbegnachstieg;
+    if (_erstbegnachstieg.contains(r'vor ')){ // ascent without known date, but before a certain year ...
+      return _erstbegnachstieg.indexOf(r'vor') == 0 ? '' : _erstbegnachstieg.substring(0,_erstbegnachstieg.indexOf(r', ')); 
+    } else{
+      return _erstbegnachstieg;
+    }
   }
 
   int get routeId {

--- a/lib/Material/RouteTile.dart
+++ b/lib/Material/RouteTile.dart
@@ -26,17 +26,24 @@ class _RouteTileState extends State<RouteTile> {
               ],
             ),*/
         title: ListTile( //Title of ExpansionTile is a ListTile
-          title: Row(
-            children: [
-              Text(_route.nr.toString()+ ' ' + _route.name),
-              (_route.commentCountInt! > 0) ? // if comment in database, show comment icon
-                Icon(
-                  Icons.comment,
-                  size: 15,
-                  ) :
-                Container (),
-            ],            
+          title: Text.rich( // use rich text to combine Text and Icon and NOT overflow on long route names
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: _route.nr.toString()+ ' ' + _route.name,
+                ),
+                WidgetSpan(
+                  child: (_route.commentCountInt! > 0) ? 
+                    Icon(
+                      Icons.comment,
+                      size: 15,
+                    )
+                    : Container(),
+                ),
+              ],
+            ),
           ),
+
           subtitle: _route.nameCZ != '2nd Language Name' ? Text(_route.nameCZ) : null, //show czech name if available
           trailing: Text(_route.grade), //show grade
         ),  
@@ -47,35 +54,20 @@ class _RouteTileState extends State<RouteTile> {
               style: TextStyle(fontSize: 10),
             ),
             title: Text(
+              _route.climbingStyle != '' ?
+              _route.climbingStyle +'\n'+ _route.description:
               _route.description,
               style: TextStyle(fontSize: 12),
             ),
-            subtitle: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: EdgeInsets.only(right: 5.0),
-                  child: Text(
-                    _route.firstAscentDate,
-                    style: TextStyle(fontSize: 12),
-                  ),
-                ),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        _route.firstAscentLead,
-                        style: TextStyle(fontSize: 12),
-                      ),
-                      Text(
-                        _route.firstAscentPartners,
-                        style: TextStyle(fontSize: 12),
-                      ),
-                    ],
-                  )
-                ),
-              ],
+            subtitle: Text( // concat string for first ascent
+              _route.firstAscentLead + 
+              (_route.firstAscentLead != '' ? ', ' : '') +
+
+              _route.firstAscentPartners + 
+              (_route.firstAscentPartners != '' ? ', ' : '') +
+              
+              _route.firstAscentDate,
+              style: TextStyle(fontSize: 12),
             ),
             onTap: () {
               CommentsSheet().showCommentsSheet(context, _route);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -151,6 +151,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   map_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_launcher_icons: ^0.9.0
   html_unescape: ^2.0.0
   html: ^0.15.0
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Route names don't overflow, 
- Ascent dates are parsed if available and use the same format (d.M.y) as in the climbing guide 
- dates like "vor 1903" are correctly parsed from nachstieg-field.
- climbing style shown in route description.
- List of first ascensionist (lead+partners) and date use same format/order as in the climbing guide 